### PR TITLE
Add support for ',' in Pn values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 TODO
+tags

--- a/lib/electr/ast/ast.rb
+++ b/lib/electr/ast/ast.rb
@@ -57,6 +57,10 @@ module Electr
     end
 
     attr_reader :value, :name
+
+    def to_f
+      value.tr(',', '_').to_f
+    end
   end
 
 end

--- a/lib/electr/evaluator.rb
+++ b/lib/electr/evaluator.rb
@@ -9,7 +9,7 @@ module Electr
     def evaluate_pn(list)
       while item = list.pop
         case item.name
-        when "numeric" then @stack.push(item.value.to_f)
+        when "numeric" then @stack.push(item.to_f)
         when "constant" then @stack.push(constant(item.value))
         when "value" then do_value(item.value)
         when "operator" then operation(item.value)

--- a/spec/ast_spec.rb
+++ b/spec/ast_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+include Electr
+
+describe AST do
+  describe AST::Pn do
+    describe '#to_f' do
+      it { expect(AST::Pn.new('1000', 'n').to_f).to eq 1000.0 }
+      it { expect(AST::Pn.new('1_000', 'n').to_f).to eq 1000.0 }
+      it { expect(AST::Pn.new('1,000', 'n').to_f).to eq 1000.0 }
+    end
+  end
+end


### PR DESCRIPTION
now, '1,000' and '1_000' should be parsed the very same.