### PR TITLE
Better values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.so
 *.o
 *.a
+.ruby-version
 mkmf.log
 TODO
 tags

--- a/lib/electr/parser/token.rb
+++ b/lib/electr/parser/token.rb
@@ -5,7 +5,7 @@ module Electr
 
       def numeric?
         # I know it isn't the best regexp I can do…
-        self =~ /\A-?[0-9\.,_]+\z/
+        self =~ /\A-?[\d\.,_]+\z/
       end
 
       def operator?
@@ -18,11 +18,11 @@ module Electr
 
       def value?
         # The unit part is redondant with Tokenizer.
-        self =~ /[0-9.][A-Za-zΩ℧μ]{1,}\z/
+        self =~ /[\d.] ?[A-Za-zΩ℧μ]{1,}\z/
       end
 
       def variable?
-        self =~ /\A[A-Z][0-9]+\z/
+        self =~ /\A[A-Z]\d+\z/
       end
 
     end

--- a/lib/electr/parser/tokenizer.rb
+++ b/lib/electr/parser/tokenizer.rb
@@ -79,8 +79,8 @@ module Electr
     end
 
     def begin_like_number?
-      @look_ahead =~ /[0-9.]/ ||
-      (@look_ahead == '-' && @codeline[@index] =~ /[0-9.]/)
+      @look_ahead =~ /[\d.]/ ||
+      (@look_ahead == '-' && @codeline[@index] =~ /[\d.]/)
     end
 
     def unary_minus?
@@ -91,7 +91,7 @@ module Electr
     end
 
     def variable?
-      @look_ahead =~ /[A-Z]/ && @codeline[@index] =~ /[0-9]/
+      @look_ahead =~ /[A-Z]/ && @codeline[@index] =~ /\d/
     end
 
     def get_unary_minus
@@ -102,7 +102,7 @@ module Electr
 
     def get_number
       add_look_ahead if @look_ahead == '-'
-      add_look_ahead while @look_ahead =~ /[0-9._,]/
+      add_look_ahead while @look_ahead =~ /[\d._,]/
       if @token[-1] != '.'
         add_look_ahead while @look_ahead =~ /[A-Za-zΩ℧μ]/
       end
@@ -111,7 +111,7 @@ module Electr
 
     def get_variable
       add_look_ahead
-      add_look_ahead while @look_ahead =~ /[0-9]/
+      add_look_ahead while @look_ahead =~ /\d/
       @token
     end
 

--- a/lib/electr/parser/value.rb
+++ b/lib/electr/parser/value.rb
@@ -31,7 +31,7 @@ module Electr
 
     def find_unit
       index = 0
-      index += 1 while @value[index] =~ /[0-9._,-]/
+      index += 1 while @value[index] =~ /[\d._, -]/
       @unit = @value[index..-1]
     end
 

--- a/spec/parser/lexer_spec.rb
+++ b/spec/parser/lexer_spec.rb
@@ -17,6 +17,10 @@ describe Lexer do
     [ :operator, UNARY_MINUS_INTERNAL_SYMBOL ],
     [ :constant, "pi" ],
     [ :value, "11K" ],
+    [ :value, "1A" ],
+    [ :value, "1mA" ],
+    [ :value, "1 A" ],
+    [ :value, "1 mA" ],
     [ :value, "11kΩ" ],
     [ :name, "foobar" ],
     [ :fname, "sqrt" ],
@@ -50,10 +54,12 @@ describe Lexer do
 
     it "accepts known units" do
       expect { Lexer.lexify("1A") }.not_to raise_error
+      expect { Lexer.lexify("1 A") }.not_to raise_error
     end
 
     it "accepts known prefixes" do
       expect { Lexer.lexify("1mA") }.not_to raise_error
+      expect { Lexer.lexify("1 mA") }.not_to raise_error
     end
 
   end

--- a/spec/parser/token_spec.rb
+++ b/spec/parser/token_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+include Electr
+
+describe String do
+  using Token
+  describe '#value?' do
+    {
+      '1A'   => 0,
+      '1mA'  => 0,
+      '1 A'  => 0,
+      '1 mA' => 0,
+      'A'    => nil,
+      'A 1'  => nil,
+      # The two following use case should probably be included as well.
+      # Determining that the string '1Q' is not a value should probably
+      # handled at the token level only, to avoid split logic.
+      # '1P'   => nil,
+      # '1wW'  => nil
+    }.each do |input, output|
+      it "#{input.inspect}.value? => #{output.inspect}" do
+        expect(input.value?).to eq output
+      end
+    end
+  end
+end

--- a/spec/parser/value_spec.rb
+++ b/spec/parser/value_spec.rb
@@ -45,5 +45,9 @@ describe LexicalUnit::Value do
       end
     end
 
+    it "accepts a space between value and unit" do
+      expect{LexicalUnit::Value.assert('1 mA')}.not_to raise_error
+    end
+
   end
 end


### PR DESCRIPTION
refer to issue #14 
'1mA' is now usable as '1 mA'

I also added a bit of tests, and updated some regexp to use \d instead of [0..9]
